### PR TITLE
Tidy up usage message formatting

### DIFF
--- a/src/Yaclp.Tests/GivenAModelWithParameterDocumentation/ModelWithParameterDocumentation.cs
+++ b/src/Yaclp.Tests/GivenAModelWithParameterDocumentation/ModelWithParameterDocumentation.cs
@@ -1,0 +1,33 @@
+using Yaclp.Attributes;
+
+namespace Yaclp.Tests.GivenAModelWithSomeParameterDescriptions
+{
+    public class ModelWithParameterDocumentation
+    {
+        [ParameterIsOptional]
+        [ParameterDescription("This is Foo")]
+        public string Foo { get; set; }
+
+        [ParameterIsOptional]
+        [ParameterDefault("Bar Default")]
+        public string Bar { get; set; }
+
+        [ParameterIsOptional]
+        [ParameterExample("Baz Example")]
+        public string Baz { get; set; }
+
+        [ParameterIsOptional]
+        public string MuchLongerParameterNameToMessUpFormatting { get; set; }
+
+        [ParameterIsOptional]
+        [ParameterExample("All Example")]
+        [ParameterDefault("All Default")]
+        [ParameterDescription("This is All")]
+        public string All { get; set; }
+
+        [ParameterIsOptional]
+        [ParameterDefault("DescAndDefault Default")]
+        [ParameterDescription("This is DescAndDefault")]
+        public string DescAndDefault { get; set; }
+    }
+}

--- a/src/Yaclp.Tests/GivenAModelWithParameterDocumentation/WhenGeneratingTheUsageMessage.cs
+++ b/src/Yaclp.Tests/GivenAModelWithParameterDocumentation/WhenGeneratingTheUsageMessage.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using Shouldly;
+using Yaclp.Tests.GivenAModelWithAllMandatoryParameters;
+
+namespace Yaclp.Tests.GivenAModelWithSomeParameterDescriptions
+{
+    [TestFixture]
+    public class WhenGeneratingTheUsageMessage : TestFor<UsageMessageBuilder>
+    {
+        private string _result;
+
+        protected override UsageMessageBuilder Given()
+        {
+            return new UsageMessageBuilder(typeof(ModelWithParameterDocumentation));
+        }
+
+        protected override void When()
+        {
+            _result = Subject.Build();
+        }
+
+        [Test]
+        public void TheMessageShouldMentionFoosDescription()
+        {
+            var fooLine = _result
+                .Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+                .Skip(3)
+                .First();
+            fooLine.ShouldBe("	Foo                                      	This is Foo ");
+        }
+
+        [Test]
+        public void TheMessageShouldMentionBarsDefault()
+        {
+            var barLine = _result
+                .Split(Environment.NewLine.ToCharArray(),StringSplitOptions.RemoveEmptyEntries)
+                .Skip(4)
+                .First();
+
+            barLine.ShouldBe("	Bar                                      	e.g. 'Bar Default'");
+        }
+
+        [Test]
+        public void TheMessageShouldMentionBazsExample()
+        {
+            var bazLine = _result
+                .Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+                .Skip(5)
+                .First();
+
+            bazLine.ShouldBe("	Baz                                      	e.g. 'Baz Example'");
+        }
+
+        [Test]
+        public void TheMessageShouldMentionLongParamsNoIdea()
+        {
+            var bazLine = _result
+                .Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+                .Skip(6)
+                .First();
+
+            bazLine.ShouldBe("	MuchLongerParameterNameToMessUpFormatting	(No idea. Sorry.)");
+        }
+
+        [Test]
+        public void TheMessageShouldMentionAllsDescriptionAndExample()
+        {
+            var bazLine = _result
+                .Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+                .Skip(7)
+                .First();
+
+            bazLine.ShouldBe("	All                                      	This is All e.g. 'All Example'");
+        }
+
+        [Test]
+        public void TheMessageShouldMentionDescAndDefaultsDescriptionAndDefault()
+        {
+            var bazLine = _result
+                .Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+                .Skip(8)
+                .First();
+
+            bazLine.ShouldBe("	DescAndDefault                           	This is DescAndDefault e.g. 'DescAndDefault Default'");
+        }
+
+        [Test]
+        public void TheDescriptionShouldBeFormattedNicely()
+        {
+            var lines = _result.Split(Environment.NewLine.ToCharArray());
+            lines.ShouldContain("	Foo                                      	This is Foo ");
+            lines.ShouldContain("	Bar                                      	e.g. 'Bar Default'");
+            lines.ShouldContain("	Baz                                      	e.g. 'Baz Example'");
+            lines.ShouldContain("	MuchLongerParameterNameToMessUpFormatting	(No idea. Sorry.)");
+            lines.ShouldContain("	All                                      	This is All e.g. 'All Example'");
+            lines.ShouldContain("	DescAndDefault                           	This is DescAndDefault e.g. 'DescAndDefault Default'");
+        }
+    }
+}

--- a/src/Yaclp.Tests/Yaclp.Tests.csproj
+++ b/src/Yaclp.Tests/Yaclp.Tests.csproj
@@ -58,6 +58,8 @@
     <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="GivenAModelWithParameterDocumentation\ModelWithParameterDocumentation.cs" />
+    <Compile Include="GivenAModelWithParameterDocumentation\WhenGeneratingTheUsageMessage.cs" />
     <Compile Include="GivenAModelWithDifferentTypesOfParameters\AllDifferentTypesOfParametersModel.cs" />
     <Compile Include="GivenAModelWithDifferentTypesOfParameters\WhenParsingValidArguments.cs" />
     <Compile Include="GivenAModelWithAllMandatoryParameters\ModelWithAllMandatoryParameters.cs" />


### PR DESCRIPTION
Padded parameter names with whitespace to align parameter descriptions to
make more readable.

Fixed description formatting so empty examples aren't shown.